### PR TITLE
Improve metadata, add versioning and contribution info

### DIFF
--- a/AlphaFind.metadata.json
+++ b/AlphaFind.metadata.json
@@ -1,13 +1,14 @@
 {
     "@context": "https://w3id.org/codemeta/3.0",
-    "type": "SoftwareSourceCode",
+    "@type": "SoftwareSourceCode",
+    "url": "https://alphafind.fi.muni.cz/",
     "applicationCategory": "Biology",
     "author": [
         {
-            "id": "http://orcid.org/0000-0003-0502-1145",
-            "type": "Person",
+            "@type": "Person",
+            "@id": "http://orcid.org/0000-0003-0502-1145",
             "affiliation": {
-                "type": "Organization",
+                "@type": "Organization",
                 "name": "Institute of Computer Science, Masaryk University, Brno, 602 00, Czech Republic"
             },
             "email": "slaninakova@ics.muni.cz",
@@ -15,20 +16,10 @@
             "givenName": "Terézia"
         },
         {
-            "type": "Role",
-            "schema:author": "http://orcid.org/0000-0003-0502-1145",
-            "roleName": "Developer"
-        },
-        {
-            "type": "Role",
-            "schema:author": "http://orcid.org/0000-0003-0502-1145",
-            "roleName": "Maintainer"
-        },
-        {
-            "id": "http://orcid.org/0009-0000-2765-8329",
-            "type": "Person",
+            "@id": "http://orcid.org/0009-0000-2765-8329",
+            "@type": "Person",
             "affiliation": {
-                "type": "Organization",
+                "@type": "Organization",
                 "name": "Faculty of Informatics, Masaryk University, Brno, 602 00, Czech Republic"
             },
             "email": "davidprochazka@mail.muni.cz",
@@ -36,38 +27,39 @@
             "givenName": "David"
         },
         {
-            "type": "Role",
-            "schema:author": "http://orcid.org/0009-0000-2765-8329",
-            "roleName": "Maintainer"
-        },
-        {
-            "type": "Role",
-            "schema:author": "http://orcid.org/0009-0000-2765-8329",
-            "roleName": "Developer"
-        },
-        {
-            "id": "http://orcid.org/0009-0001-7780-3317",
-            "type": "Person",
+            "@id": "http://orcid.org/0009-0001-7780-3317",
+            "@type": "Person",
             "affiliation": {
-                "type": "Organization",
+                "@type": "Organization",
                 "name": "Institute of Computer Science, Masaryk University, Brno, 602 00, Czech Republic"
             },
             "email": "524749@muni.cz",
             "familyName": "Čillík",
             "givenName": "Jakub"
+        }
+    ],
+    "maintainer": [
+        {
+          "@type": "Person",
+          "givenName": "Terézia",
+          "familyName": "Slanináková",
+          "email": "slaninakova@ics.muni.cz",
+          "@id": "http://orcid.org/0000-0003-0502-1145"
         },
         {
-            "type": "Role",
-            "schema:author": "http://orcid.org/0009-0001-7780-3317",
-            "roleName": "Developer"
+          "@type": "Person",
+          "givenName": "David",
+          "familyName": "Procházka",
+          "email": "davidprochazka@mail.muni.cz",
+          "@id": "http://orcid.org/0009-0000-2765-8329"
         }
     ],
     "contributor": [
         {
-            "id": "http://orcid.org/0000-0003-0502-1145",
-            "type": "Person",
+            "@id": "http://orcid.org/0000-0003-0502-1145",
+            "@type": "Person",
             "affiliation": {
-                "type": "Organization",
+                "@type": "Organization",
                 "name": "Institute of Computer Science, Masaryk University, Brno, 602 00, Czech Republic"
             },
             "email": "slaninakova@ics.muni.cz",
@@ -75,20 +67,20 @@
             "givenName": "Terézia"
         },
         {
-            "type": "Role",
+            "@type": "Role",
             "schema:author": "http://orcid.org/0000-0003-0502-1145",
             "roleName": "Maintainer"
         },
         {
-            "type": "Role",
+            "@type": "Role",
             "schema:author": "http://orcid.org/0000-0003-0502-1145",
             "roleName": "Developer"
         },
         {
-            "id": "http://orcid.org/0009-0000-2765-8329",
-            "type": "Person",
+            "@id": "http://orcid.org/0009-0000-2765-8329",
+            "@type": "Person",
             "affiliation": {
-                "type": "Organization",
+                "@type": "Organization",
                 "name": "Faculty of Informatics, Masaryk University, Brno, 602 00, Czech Republic"
             },
             "email": "davidprochazka@mail.muni.cz",
@@ -96,13 +88,25 @@
             "givenName": "David"
         },
         {
-            "type": "Role",
+            "@type": "Role",
             "schema:author": "http://orcid.org/0009-0000-2765-8329",
             "roleName": "Maintainer"
         },
         {
-            "type": "Role",
+            "@type": "Role",
             "schema:author": "http://orcid.org/0009-0000-2765-8329",
+            "roleName": "Developer"
+        },
+        {
+            "@type": "Person",
+            "givenName": "Jakub",
+            "familyName": "Čillík",
+            "email": "524749@muni.cz",
+            "@id": "http://orcid.org/0009-0001-7780-3317"
+        },
+        {
+            "@type": "Role",
+            "schema:author": "http://orcid.org/0009-0001-7780-3317",
             "roleName": "Developer"
         }
     ],
@@ -112,12 +116,12 @@
     "datePublished": "2024-02-18",
     "description": "AlphaFind is a web-based search engine that allows for structure-based search of the entire AlphaFold Protein Structure Database. Uniprot ID, PDB ID, or Gene Symbol is accepted as input – the engine will return the most similar proteins found within AlphaFold DB, with an option for additional search to extend and refine the results. The search results are grouped by their source organism and displayed along with several similarity metrics. 3D visualizations of the structural superposition of the proteins are provided, and text filters can be used to find specific organisms or Uniprot IDs. For details about the methodology and usage, please see the manual. This website is free and open to all users and there is no login requirement.",
     "downloadUrl": "https://github.com/Coda-Research-Group/AlphaFind/archive/refs/heads/main.zip",
+    "installUrl": "https://github.com/Coda-Research-Group/AlphaFind#Installation",
     "funder": {
         "type": "Organization",
         "name": "Czech Science Foundation"
     },
     "identifier": "https://zenodo.org/doi/10.5281/zenodo.11085862",
-    "isPartOf": "https://alphafind.fi.muni.cz/",
     "keywords": [
         "similarity search",
         "structural similarity",
@@ -133,11 +137,12 @@
         "MacOS"
     ],
     "programmingLanguage": [
-        "Python3",
+        "Python",
         "TypeScript",
-        "JavaScipt",
+        "JavaScript",
         "Shell",
-        "HTML"
+        "HTML",
+        "SCSS"
     ],
     "releaseNotes": "Initial Release",
     "softwareRequirements": "Docker",
@@ -146,5 +151,63 @@
     "funding": "GF23-07040K",
     "isSourceCodeOf": "https://alphafind.fi.muni.cz/",
     "issueTracker": "https://github.com/Coda-Research-Group/AlphaFind/issues",
-    "referencePublication": "https://doi.org/10.1093/nar/gkae397"
+    "contIntegration": "https://github.com/Coda-Research-Group/AlphaFind/actions",
+    "citation": [
+        {
+            "@type": "ScholarlyArticle",
+            "name": "AlphaFind: discover structure similarity across the proteome in AlphaFold DB",
+            "author": [
+                "Procházka, D.",
+                "Slanináková, T.",
+                "Olha, J.",
+                "Rošinec, A.",
+                "Grešová, K.",
+                "Jánošová, M.",
+                "Čillík, J.",
+                "Porubská J.",
+                "Svobodová R.",
+                "Dohnal V.",
+                "Antol, M."
+            ],
+            "url": "https://doi.org/10.1093/nar/gkae397",
+            "datePublished": "2024"
+        }
+      ],
+      "referencePublication": [
+        {
+          "@type": "ScholarlyArticle",
+          "name": "AlphaFind: discover structure similarity across the proteome in AlphaFold DB",
+          "author": [
+                "Procházka, D.",
+                "Slanináková, T.",
+                "Olha, J.",
+                "Rošinec, A.",
+                "Grešová, K.",
+                "Jánošová, M.",
+                "Čillík, J.",
+                "Porubská J.",
+                "Svobodová R.",
+                "Dohnal V.",
+                "Antol, M."
+            ],
+          "url": "https://doi.org/10.1093/nar/gkae397",
+          "datePublished": "2024"
+        }
+      ],
+      "isPartOf": [
+        {
+          "@type": "Dataset",
+          "name": "AlphaFind: Discover structure similarity across the entire known proteome – data and model",
+          "url": "https://doi.org/10.48700/datst.d35zf-1ja47",
+          "description": "AlphaFind is a web-based search engine for fast structure-based searching of the entire AlphaFold DB protein structures. This repository contains compact vector embeddings for 214M protein structures, grouped into 2000 clusters, along with a classification neural network, enabling efficient pre-filtering of candidate answers for protein similarity searches.",
+          "license": "https://creativecommons.org/licenses/by/4.0/"
+        },
+        {
+          "@type": "Dataset",
+          "name": "AlphaFold Database",
+          "description": "The AlphaFold Database (AFDB) is a collection of over 214 million protein structure models, each with a unique identifier. These models are derived from the AlphaFold protein structure prediction algorithm and are used for a variety of scientific and research purposes.",
+          "url": "https://github.com/google-deepmind/alphafold/tree/main/afdb",
+          "license": "https://www.apache.org/licenses/LICENSE-2.0"
+        }
+    ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,33 @@
+# Changelog
+
+All notable changes to AlphaFind will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [1.0.0] - 2024-04-29
+
+### Added
+- Initial release of AlphaFind
+- Web-based search engine for structure-based search of the AlphaFold Protein Structure Database
+- Support for input via Uniprot ID, PDB ID, or Gene Symbol
+- Results grouped by source organism with similarity metrics
+- 3D visualizations of structural superposition
+- Text filters for finding specific organisms or Uniprot IDs
+
+### Changed
+- N/A (initial release)
+
+### Deprecated
+- N/A (initial release)
+
+### Removed
+- N/A (initial release)
+
+### Fixed
+- N/A (initial release)
+
+### Security
+- N/A (initial release)
+
+[1.0.0]: https://github.com/Coda-Research-Group/AlphaFind/releases/tag/v1.0.0

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,40 @@
+# Contributing to AlphaFind
+
+We welcome contributions to AlphaFind! This document outlines the process for contributing to this project.
+
+## Getting Started
+
+1. Fork the repository on GitHub.
+2. Clone your fork locally: `git clone https://github.com/your-username/AlphaFind.git`
+3. Create a new branch for your feature or bug fix: `git checkout -b your-feature-name`
+
+## Making Changes
+
+1. Make your changes in your feature branch.
+2. Add or update tests as necessary.
+3. Ensure all tests pass.
+4. Update documentation if required.
+
+## Submitting Changes
+
+1. Push your changes to your fork on GitHub.
+2. Submit a pull request to the main AlphaFind repository.
+3. Describe your changes in detail in the pull request description.
+
+## Code Style
+
+- Follow the existing code style in the project.
+- Use meaningful variable and function names.
+- Comment your code where necessary.
+
+## Reporting Issues
+
+- Use the GitHub issue tracker to report bugs or suggest features.
+- Provide as much detail as possible, including steps to reproduce for bugs.
+
+## Community
+
+- Be respectful and considerate in all interactions.
+- Help others who have questions.
+
+Thank you for contributing to AlphaFind!


### PR DESCRIPTION
Improved the findability and reproducibility of AlphaFind by:
- FRSM-05-R1-2: improving machine readability of the metadata file (e.g. "@type" instead of "type")
- FRSM-04-F2-2: improving the "programmingLanguage" part
- FRSM-04-F2: adding a new "installUrl", "continuousIntegration", "referencePublication"
- FRSM-15-R1.2: improving the "isPartOf" to include the relevant data repositories
- FRSM-05-R1: adding CHANGELOG and CONTRIBUTING (development metadata)