### PR TITLE
Fix Null Dereference in FilterInfo Component

### DIFF
--- a/ui/src/components/FilterInfo/FilterInfo.tsx
+++ b/ui/src/components/FilterInfo/FilterInfo.tsx
@@ -11,7 +11,7 @@ export function FilterInfo({ filteredCount, totalCount }: Props) {
 
     return (
         <div className="disabled">
-            Most similar proteins to <i>{queryObject.uniProtId}</i> (showing {filteredCount} filtered out of {totalCount})
+            Most similar proteins to <i>{queryObject?.uniProtId || "unknown"}</i> (showing {filteredCount} filtered out of {totalCount})
         </div>
     );
 }


### PR DESCRIPTION
The `FilterInfo` component was accessing `queryObject.uniProtId` without checking if `queryObject` exists. Since `queryObject` is retrieved from context, it can be null during initial load or before the provider is ready. 

This PR adds optional chaining and a fallback value to prevent runtime crashes.

---

*This PR was generated by [PRJanitor](https://prjanitor.com) — an automated tool that finds and fixes small bugs in open-source projects.*

We respect your contribution guidelines — if your project doesn't accept bot PRs, we won't send more. You can also add a `.github/prjanitor.yml` file with `enabled: false` to opt out explicitly.